### PR TITLE
External links now have icons

### DIFF
--- a/css/master.css
+++ b/css/master.css
@@ -163,3 +163,14 @@ a {
   font-size: .8em;
 }
 .red { color: #DB3207; }
+
+a.external.clearnet { color: orange; }
+
+a.external.clearnet::after { content: " ⚠"; }
+
+a.external.zeronet {
+  background-image: linear-gradient(transparent,transparent), url(data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22%20standalone%3D%22no%22%3F%3E%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%2212%22%3E%3Cpath%20fill%3D%22%23fff%22%20stroke%3D%22%2306c%22%20d%3D%22M1.5%204.518h5.982V10.5H1.5z%22%2F%3E%3Cpath%20d%3D%22M5.765%201H11v5.39L9.427%207.937l-1.31-1.31L5.393%209.35l-2.69-2.688%202.81-2.808L4.2%202.544z%22%20fill%3D%22%2306f%22%2F%3E%3Cpath%20d%3D%22M9.995%202.004l.022%204.885L8.2%205.07%205.32%207.95%204.09%206.723l2.882-2.88-1.85-1.852z%22%20fill%3D%22%23fff%22%2F%3E%3C%2Fsvg%3E);
+  background-repeat: no-repeat;
+  background-position: center right;
+  padding-right: 13px;
+}

--- a/js/ZeroWiki.coffee
+++ b/js/ZeroWiki.coffee
@@ -270,8 +270,8 @@ class ZeroWiki extends ZeroFrame
       existingPages = LinkHelper.getSlugs(false, slugs)
 
       for link in links
-        cssClass = ""
-        cssClass = "red" unless link.slug in existingPages
+        cssClass = "internal"
+        cssClass += " red" unless link.slug in existingPages
         replace = "<a href=\"?Page:#{link.slug}\" class=\"#{cssClass}\">#{link.text}</a>"
         link.tag = link.tag.replace /([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1"
         HTMLcontent = HTMLcontent.replace(new RegExp(link.tag, "g"), replace)

--- a/js/utils/WikiUi.coffee
+++ b/js/utils/WikiUi.coffee
@@ -118,6 +118,12 @@ class WikiUi
   loadContent: (originalContent, HTMLContent, rev=null) ->
     @contentEditor.innerHTML = originalContent
     @contentPanel.innerHTML  = HTMLContent
+    for link in @contentPanel.querySelectorAll('a:not(.internal)')
+      link.className += ' external'
+      if link.href.indexOf(location.origin) == 0
+        link.className += ' zeronet'
+      else
+        link.className += ' clearnet'
     @showContent(rev)
 
   #


### PR DESCRIPTION
External zeronet links now have square icon (as wikipedia does)
External clearnet links now have warning orange icon (as hidden wiki does)

It does all the changes proposed in issue #2.

There are now css classes `internal`, `external`, `clearnet` and `zeronet`, used for the links.
